### PR TITLE
[BUGFIX]: remove fallback use of DSSKeys. no longer supported

### DIFF
--- a/pysftp/__init__.py
+++ b/pysftp/__init__.py
@@ -11,7 +11,7 @@ import warnings
 
 import paramiko
 from paramiko import SSHException, AuthenticationException   # make available
-from paramiko import AgentKey, RSAKey, DSSKey
+from paramiko import AgentKey, RSAKey
 from paramiko.hostkeys import HostKeys
 
 from pysftp.exceptions import (CredentialException, ConnectionException,
@@ -159,10 +159,8 @@ class Connection(object):   # pylint:disable=r0902,r0904
                 try:  # try rsa
                     self._tconnect['pkey'] = RSAKey.from_private_key_file(
                         private_key_file, private_key_pass)
-                except paramiko.SSHException:   # if it fails, try dss
-                    # pylint:disable=r0204
-                    self._tconnect['pkey'] = DSSKey.from_private_key_file(
-                        private_key_file, private_key_pass)
+                except paramiko.SSHException:   # if it fails, raise error
+                    raise CredentialException("Failed to load private key from %s." % private_key_file)    
 
     def _start_transport(self, host, port):
         '''start the transport and set the ciphers if specified.'''
@@ -448,7 +446,6 @@ class Connection(object):   # pylint:disable=r0902,r0904
 
     def putfo(self, flo, remotepath=None, file_size=0, callback=None,
               confirm=True):
-
         """Copies the contents of a file like object to remotepath.
 
         :param flo: a file-like object that supports .read()


### PR DESCRIPTION
Remove DSSKeys paramiko dependency, following this pr of the [original library](https://bitbucket.org/dundeemt/pysftp/pull-requests/9/overview)

in paramiko 4.0.0 the support for DSSKeys has been removed.

the statement “from paramiko import DSSKey” now results in an errror

logical solution is to remove the fallback use of DSSKey. This solves the import error. If use of RSAKey method fails, the error is catched.